### PR TITLE
Feature/mock

### DIFF
--- a/src/AI/MockVendor.php
+++ b/src/AI/MockVendor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gptsdk\AI;
+
+use Gptsdk\Interfaces\AIVendor;
+use Gptsdk\Types\AiRequest;
+use Gptsdk\Types\MockResponse;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+use function json_encode;
+use function sha1;
+
+class MockVendor implements AIVendor
+{
+    public function complete(AiRequest $aiRequest): ResponseInterface
+    {
+        $mockHash = sha1((string) json_encode($aiRequest->variableValues));
+
+        return new MockResponse($aiRequest->prompt->mocks[$mockHash]?->output ?? []);
+    }
+}

--- a/src/Storage/GithubPromptStorage.php
+++ b/src/Storage/GithubPromptStorage.php
@@ -16,6 +16,7 @@ use Gptsdk\Execption\PromptStorageIssue;
 use Gptsdk\Interfaces\PromptStorage;
 use Gptsdk\Types\Prompt;
 use Gptsdk\Types\PromptMessage;
+use Gptsdk\Types\PromptMock;
 use Gptsdk\Types\PromptVariable;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -88,6 +89,13 @@ class GithubPromptStorage implements PromptStorage
                 compilerType:
                     CompilerType::tryFrom((string) ($promptArray['compilerType'] ?? '')) ??
                     CompilerType::DOUBLE_BRACKETS,
+                mocks: array_map(
+                    fn (array $mock) => new PromptMock(
+                        variableValues: (array) $mock['variableValues'],
+                        output: (array) $mock['output'],
+                    ),
+                    (array) ($promptArray['mocks'] ?? []),
+                ),
             );
 
             $this->cacheStorage?->setPromptCache($prompt);

--- a/src/Storage/TempLocalPromptStorage.php
+++ b/src/Storage/TempLocalPromptStorage.php
@@ -15,6 +15,7 @@ use Gptsdk\Enum\CompilerType;
 use Gptsdk\Interfaces\PromptStorage;
 use Gptsdk\Types\Prompt;
 use Gptsdk\Types\PromptMessage;
+use Gptsdk\Types\PromptMock;
 use Gptsdk\Types\PromptVariable;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -82,6 +83,13 @@ class TempLocalPromptStorage implements PromptStorage
             ),
             compilerType: CompilerType::tryFrom((string) ($promptArray['compilerType'] ?? '')) ??
                 CompilerType::DOUBLE_BRACKETS,
+            mocks: array_map(
+                fn (array $mock) => new PromptMock(
+                    variableValues: (array) $mock['variableValues'],
+                    output: (array) $mock['output'],
+                ),
+                (array) ($promptArray['mocks'] ?? []),
+            ),
         );
     }
 

--- a/src/Types/MockResponse.php
+++ b/src/Types/MockResponse.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gptsdk\Types;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+use function json_encode;
+
+class MockResponse implements ResponseInterface
+{
+    /**
+     * @param array<mixed> $output
+     */
+    public function __construct(private readonly array $output)
+    {
+    }
+
+    public function getStatusCode(): int
+    {
+        return 200;
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function getHeaders(bool $throw = true): array
+    {
+        return [];
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        return (string) json_encode($this->output);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        return $this->output;
+    }
+
+    public function cancel(): void
+    {
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return [];
+    }
+}

--- a/src/Types/Prompt.php
+++ b/src/Types/Prompt.php
@@ -18,12 +18,14 @@ class Prompt
     /**
      * @param PromptMessage[] $messages
      * @param PromptVariable[] $variables
+     * @param PromptMock[] $mocks
      */
     public function __construct(
         public readonly string $path,
         public readonly array $messages,
         public readonly array $variables,
         public readonly CompilerType $compilerType,
+        public readonly array $mocks,
     ) {
     }
 }

--- a/src/Types/PromptMock.php
+++ b/src/Types/PromptMock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gptsdk\Types;
+
+use JsonSerializable;
+
+class PromptMock implements JsonSerializable
+{
+    /**
+     * @param array<mixed, mixed> $variableValues
+     * @param array<mixed, mixed> $output
+     */
+    public function __construct(
+        public readonly array $variableValues,
+        public readonly array $output,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'output' => $this->output,
+            'variableValues' => $this->variableValues,
+        ];
+    }
+}

--- a/tests/Storage/TempLocalPromptStorageTest.php
+++ b/tests/Storage/TempLocalPromptStorageTest.php
@@ -34,6 +34,7 @@ class TempLocalPromptStorageTest extends TestCase
                 [new PromptMessage('User', 'Hello OpenAI!')],
                 [new PromptVariable('who', 'string')],
                 CompilerType::DOUBLE_BRACKETS,
+                mocks: [],
             ),
         );
 


### PR DESCRIPTION
This pull request introduces a mock AI vendor implementation and updates the prompt storage to support mock data. It also includes new tests to verify the functionality of the mock AI vendor.

### Mock AI Vendor Implementation:

* [`src/AI/MockVendor.php`](diffhunk://#diff-1464eb51d1ead66649f594a6b8fa0afa5971a4b400955a596cd325f6f96bbaecR1-R23): Added a new `MockVendor` class implementing the `AIVendor` interface to provide mock responses for AI requests.
* [`src/Types/MockResponse.php`](diffhunk://#diff-6d6210293d1f19ca4184c4f583db5fa12c07042b16763d27cf897cd7223d573bR1-R54): Created a `MockResponse` class implementing the `ResponseInterface` to handle mock responses.

### Prompt Storage Updates:

* `src/Storage/GithubPromptStorage.php` and `src/Storage/TempLocalPromptStorage.php`: Updated the `getPrompt` method to include `PromptMock` instances, allowing the storage to handle mock data. [[1]](diffhunk://#diff-0c70b1eb73c32a25f1c1b7b4688c2ba5d9ea50b6367269b2dfb01d8c50376bd6R92-R98) [[2]](diffhunk://#diff-472c2f1b1ed9c26a71c7fe9409e9f886a5d16b896b9c72645d5eec94b9753dcfR86-R92)
* [`src/Types/Prompt.php`](diffhunk://#diff-f5a054adc84cad8709a0c710fdf9c0f2027dbf13b7ce2bd3aebe7a5746cf2e61R21-R28): Modified the `Prompt` class constructor to accept an array of `PromptMock` objects.
* [`src/Types/PromptMock.php`](diffhunk://#diff-6b17de7d29ae6028ec73b5d2b59d4e73b8256f1c29364645bc0067c68edfcc67R1-R31): Added a new `PromptMock` class to represent mock data for prompts.

### Testing Enhancements:

* [`tests/AI/CompletionAiTest.php`](diffhunk://#diff-ed2568dc88276031eadb08b880fa57f6db3aef8fa6b0c7a12b1277d71f252b2dR140-R204): Added a new test method `testCompleteMock` to verify the functionality of `MockVendor` with `CompletionAi`.
* [`tests/Storage/TempLocalPromptStorageTest.php`](diffhunk://#diff-619468defc2d1e78b18f9b9707daee9d076fb7609b7f24f3e8aae6c7b284d5f1R37): Updated the `testGetPrompt` method to include mock data in the prompt.